### PR TITLE
docs: add isContactFormEditable doc

### DIFF
--- a/integrations/web-booking-form.md
+++ b/integrations/web-booking-form.md
@@ -10,6 +10,7 @@ input form is a json object encoded in base64 with following format:
 
 ```
     {
+      "isContactFormEditable": true, // default: true, when `false` the data in `customer` would be disabled in the contact form if that customer property has value
       "language": "zh-TW",
       "customer": {
         "name": "inline",


### PR DESCRIPTION
## Related Asana Task
- https://app.asana.com/0/1203143758299431/1204510698402901/f

### What is the feature?
When we get the customized URL in the booking server, we will let the booking client know the contact form cannot edit pre-filled fields

### What is the solution?
- Add new key to control if contact form is ediatble
    - key: `isContactFormEditable`
 
### What areas of the site does it impact?
- If has `isContactFormEditable: false` in pre-filled-form, the provided data in contact form will be disabled:
    - booking
    - food ordering

## Other Notes
- related PR:
    -  https://github.com/inlineapps/inline-web/pull/2974