### PR TITLE
docs: add externalId in pre-filled form

### DIFF
--- a/integrations/web-booking-form.md
+++ b/integrations/web-booking-form.md
@@ -43,6 +43,7 @@ input form is a json object encoded in base64 with following format:
         "id": "-eEDSsdxwewcwwd",
         "time": 1675062040694
       },
+      "externalId": 'A123' // Only support in food ordering, if you want to record a relation between inline order with your system, you can define the externalId
     }
 ```
 


### PR DESCRIPTION
## Related Asana Task
- https://app.asana.com/0/1203143758299431/1205219358140696/f

## Context
- Add `externalId` in pre-filled form doc
    - `The external id, the merchant can define their own meaning`

## Other Notes
- [Related Mock up](https://inline.canny.io/merchant-requests/p/twthe-fo-contact-information-page-has-additional-fields-to-enter)

## Dependent PRs
- none
